### PR TITLE
Replace ’ with '. The ’ character cannot be converted to other charsets

### DIFF
--- a/utf8.js
+++ b/utf8.js
@@ -127,7 +127,7 @@
 			return continuationByte & 0x3F;
 		}
 
-		// If we end up here, it’s not a continuation byte
+		// If we end up here, it's not a continuation byte
 		throw Error('Invalid continuation byte');
 	}
 


### PR DESCRIPTION
I suggest this change due to a problem I've encountered. The UTF8 character `’` (U+2019) can’t be converted to other charsets (ASCII-8BIT in my case) which causes an error like that:

> incompatible character encodings: ASCII-8BIT and UTF-8