### PR TITLE
Fixed decoding of four-byte code points

### DIFF
--- a/utf8.js
+++ b/utf8.js
@@ -184,7 +184,7 @@
 			byte2 = readContinuationByte();
 			byte3 = readContinuationByte();
 			byte4 = readContinuationByte();
-			codePoint = ((byte1 & 0x0F) << 0x12) | (byte2 << 0x0C) |
+			codePoint = ((byte1 & 0x07) << 0x12) | (byte2 << 0x0C) |
 				(byte3 << 0x06) | byte4;
 			if (codePoint >= 0x010000 && codePoint <= 0x10FFFF) {
 				return codePoint;


### PR DESCRIPTION
Much too lazy to actually test but I was using this wonderful repo as a reference for my own implementation and found this typo